### PR TITLE
Add LLMO field to pages

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,17 @@
+<?php
+defined('TYPO3') or die();
+
+call_user_func(function () {
+    $newColumns = [
+        'tx_llmstxt_llmo' => [
+            'label' => 'LLMO',
+            'config' => [
+                'type' => 'text',
+                'enableRichtext' => false,
+            ],
+        ],
+    ];
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $newColumns);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', '--div--;LLMO,tx_llmstxt_llmo');
+});

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -9,6 +9,12 @@
             <trans-unit id="extension.description" resname="extension.description">
                 <source>Provides llms.txt file generation for LLM-friendly content</source>
             </trans-unit>
+            <trans-unit id="tab.llmo" resname="tab.llmo">
+                <source>LLMO</source>
+            </trans-unit>
+            <trans-unit id="field.tx_llmstxt_llmo" resname="field.tx_llmstxt_llmo">
+                <source>LLMO Property</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,3 @@
+CREATE TABLE pages (
+    tx_llmstxt_llmo text
+);


### PR DESCRIPTION
## Summary
- add LLMO field to `pages` table
- add TCA override showing the field on a new backend tab
- provide translations for the new tab and field label

## Testing
- `composer validate --no-check-publish`
- `php -l Configuration/TCA/Overrides/pages.php`
- `php -l ext_localconf.php`
- `find Classes Configuration -name '*.php' -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_b_688ca54d3b148324bcb60c825d6f1b95