### PR TITLE
Add LLMs description field to pages

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,23 @@
+<?php
+defined('TYPO3') or die();
+
+call_user_func(function () {
+    $newColumns = [
+        'tx_llmstxt_llms_description' => [
+            'label' => 'LLMs description',
+            'description' => 'Description used by LLMs for this page.',
+            'config' => [
+                'type' => 'text',
+                'enableRichtext' => false,
+            ],
+        ],
+    ];
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $newColumns);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+        'pages',
+        '--div--;LLMO,tx_llmstxt_llms_description',
+        '',
+        'after:seo'
+    );
+});

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -9,6 +9,15 @@
             <trans-unit id="extension.description" resname="extension.description">
                 <source>Provides llms.txt file generation for LLM-friendly content</source>
             </trans-unit>
+            <trans-unit id="tab.llmo" resname="tab.llmo">
+                <source>LLMO</source>
+            </trans-unit>
+            <trans-unit id="field.tx_llmstxt_llms_description" resname="field.tx_llmstxt_llms_description">
+                <source>LLMs description</source>
+            </trans-unit>
+            <trans-unit id="field.tx_llmstxt_llms_description.description" resname="field.tx_llmstxt_llms_description.description">
+                <source>Description used by LLMs for this page.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,4 @@
+CREATE TABLE pages (
+    tx_llmstxt_llms_description text
+);
+


### PR DESCRIPTION
## Summary
- rename page property to "LLMs description" with helper text
- show field on a new tab after the core SEO tab
- update database schema and translations

## Testing
- `composer validate --no-check-publish`
- `php -l Configuration/TCA/Overrides/pages.php`
- `php -l ext_localconf.php`
- `find Classes Configuration -name '*.php' -print | xargs -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_b_688ca54d3b148324bcb60c825d6f1b95