### PR TITLE
Fix missing semicolon in pages TCA override

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -13,7 +13,7 @@ call_user_func(function () {
         ],
     ];
 
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $newColumns)
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $newColumns);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
         'pages',
         '--div--;LLMO,tx_llmstxt_llms_description',


### PR DESCRIPTION
## Summary
- terminate TCA override syntax error by ending addTCAcolumns call with semicolon

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l 2>&1 | head -n 200`

------
https://chatgpt.com/codex/tasks/task_b_68908584ddcc83249bcab4dfda5e5371