### PR TITLE
Add LLMs section records and page assignment

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -4,19 +4,32 @@ defined('TYPO3') or die();
 call_user_func(function () {
     $newColumns = [
         'tx_llmstxt_llms_description' => [
-            'label' => 'LLMs description',
-            'description' => 'Description used by LLMs for this page.',
+            'label' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:field.tx_llmstxt_llms_description',
+            'description' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:field.tx_llmstxt_llms_description.description',
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => false,
             ],
         ],
+        'tx_llmstxt_section' => [
+            'label' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:field.tx_llmstxt_section',
+            'description' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:field.tx_llmstxt_section.description',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', 0],
+                ],
+                'foreign_table' => 'tx_llmstxt_section',
+                'default' => 0,
+            ],
+        ],
     ];
 
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $newColumns)
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $newColumns);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
         'pages',
-        '--div--;LLMO,tx_llmstxt_llms_description',
+        '--div--;LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:tab.llmo,tx_llmstxt_llms_description,tx_llmstxt_section',
         '',
         'after:seo'
     );

--- a/Configuration/TCA/tx_llmstxt_section.php
+++ b/Configuration/TCA/tx_llmstxt_section.php
@@ -1,0 +1,60 @@
+<?php
+return [
+    'ctrl' => [
+        'title' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:table.section',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+        ],
+        'searchFields' => 'title',
+        'iconfile' => 'EXT:core/Resources/Public/Icons/T3Icons/svgs/m/apps/pagetree-page.svg',
+    ],
+    'types' => [
+        '1' => ['showitem' => 'title, --div--;LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.visibility, hidden, starttime, endtime'],
+    ],
+    'columns' => [
+        'title' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.title',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'eval' => 'trim,required',
+            ],
+        ],
+        'hidden' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
+            'config' => [
+                'type' => 'check',
+                'renderType' => 'checkboxToggle',
+            ],
+        ],
+        'starttime' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'eval' => 'datetime',
+                'default' => 0,
+            ],
+        ],
+        'endtime' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'eval' => 'datetime',
+                'default' => 0,
+            ],
+        ],
+    ],
+];
+

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -18,6 +18,15 @@
             <trans-unit id="field.tx_llmstxt_llms_description.description" resname="field.tx_llmstxt_llms_description.description">
                 <source>Description used by LLMs for this page.</source>
             </trans-unit>
+            <trans-unit id="field.tx_llmstxt_section" resname="field.tx_llmstxt_section">
+                <source>LLMs section</source>
+            </trans-unit>
+            <trans-unit id="field.tx_llmstxt_section.description" resname="field.tx_llmstxt_section.description">
+                <source>Section this page belongs to.</source>
+            </trans-unit>
+            <trans-unit id="table.section" resname="table.section">
+                <source>LLMs sections</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,4 +1,18 @@
 CREATE TABLE pages (
-    tx_llmstxt_llms_description text
+    tx_llmstxt_llms_description text,
+    tx_llmstxt_section int DEFAULT 0 NOT NULL
+);
+
+CREATE TABLE tx_llmstxt_section (
+    uid int AUTO_INCREMENT PRIMARY KEY,
+    pid int DEFAULT 0 NOT NULL,
+    tstamp int DEFAULT 0 NOT NULL,
+    crdate int DEFAULT 0 NOT NULL,
+    cruser_id int DEFAULT 0 NOT NULL,
+    deleted tinyint(4) DEFAULT 0 NOT NULL,
+    hidden tinyint(4) DEFAULT 0 NOT NULL,
+    starttime int DEFAULT 0 NOT NULL,
+    endtime int DEFAULT 0 NOT NULL,
+    title varchar(255) DEFAULT '' NOT NULL
 );
 


### PR DESCRIPTION
## Summary
- add DB table for `tx_llmstxt_section` and TCA setup
- expose `LLMs section` select field on pages and allow saving via record
- replace hard-coded labels with localized strings and drop obsolete table registration

## Testing
- `composer install`
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689084bf73bc8324ab3a270062a40ba7