### PR TITLE
Fix SEO tab sections placement

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -31,6 +31,6 @@ call_user_func(function () {
         'pages',
         '--div--;LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:tab.llmo,tx_llmstxt_llms_description,tx_llmstxt_section',
         '',
-        'after:seo'
+        'after:--div--;LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.tabs.seo'
     );
 });


### PR DESCRIPTION
## Summary
- ensure canonical, structured data, and sitemap remain on SEO tab by inserting LLMO tab after existing SEO tab

## Testing
- `php -l Configuration/TCA/Overrides/pages.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_b_689089e9a4748324b4a50e330cb6e7e2