### PR TITLE
feat: add page indexing toggle for llms.txt

### DIFF
--- a/Classes/Service/LlmsTxtGenerator.php
+++ b/Classes/Service/LlmsTxtGenerator.php
@@ -210,6 +210,12 @@ class LlmsTxtGenerator
                 return;
             }
         }
+        if ((int)($page['tx_llmstxt_index'] ?? 1) === 0) {
+            foreach ($node['children'] as $child) {
+                $this->addSectionsRecursively($sections, $child, $site, $languageId);
+            }
+            return;
+        }
         if (in_array((int)$page['doktype'], [254, 199, 4], true)) {
             foreach ($node['children'] as $child) {
                 $this->addSectionsRecursively($sections, $child, $site, $languageId);
@@ -246,6 +252,13 @@ class LlmsTxtGenerator
     {
         foreach ($pageTree as $node) {
             $page = $node['page'];
+
+            if ((int)($page['tx_llmstxt_index'] ?? 1) === 0) {
+                if (!empty($node['children'])) {
+                    $this->addPagesToSection($section, $node['children'], $site, $languageId, $prefix);
+                }
+                continue;
+            }
 
             if (in_array((int)$page['doktype'], [254, 199, 4], true)) {
                 if (!empty($node['children'])) {

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -3,6 +3,14 @@ defined('TYPO3') or die();
 
 call_user_func(function () {
     $newColumns = [
+        'tx_llmstxt_index' => [
+            'label' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:field.tx_llmstxt_index',
+            'description' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:field.tx_llmstxt_index.description',
+            'config' => [
+                'type' => 'check',
+                'default' => 1,
+            ],
+        ],
         'tx_llmstxt_llms_description' => [
             'label' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:field.tx_llmstxt_llms_description',
             'description' => 'LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:field.tx_llmstxt_llms_description.description',
@@ -29,7 +37,7 @@ call_user_func(function () {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $newColumns);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
         'pages',
-        '--div--;LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:tab.llmo,tx_llmstxt_llms_description,tx_llmstxt_section',
+        '--div--;LLL:EXT:llms_txt/Resources/Private/Language/locallang.xlf:tab.llmo,tx_llmstxt_index,tx_llmstxt_llms_description,tx_llmstxt_section',
         ''
     );
 });

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -12,6 +12,12 @@
             <trans-unit id="tab.llmo" resname="tab.llmo">
                 <source>LLMO</source>
             </trans-unit>
+            <trans-unit id="field.tx_llmstxt_index" resname="field.tx_llmstxt_index">
+                <source>LLM index this page</source>
+            </trans-unit>
+            <trans-unit id="field.tx_llmstxt_index.description" resname="field.tx_llmstxt_index.description">
+                <source>Include this page in the LLM index.</source>
+            </trans-unit>
             <trans-unit id="field.tx_llmstxt_llms_description" resname="field.tx_llmstxt_llms_description">
                 <source>LLMs description</source>
             </trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,4 +1,5 @@
 CREATE TABLE pages (
+    tx_llmstxt_index tinyint(1) DEFAULT 1 NOT NULL,
     tx_llmstxt_llms_description text,
     tx_llmstxt_section int DEFAULT 0 NOT NULL
 );


### PR DESCRIPTION
## Summary
- add `LLM index this page` checkbox to pages in LLMO tab
- support skipping pages flagged for no indexing in llms.txt generation

## Testing
- `php -l Configuration/TCA/Overrides/pages.php`
- `php -l Classes/Service/LlmsTxtGenerator.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_b_6890a1584478832498a76e32a038fac7