### PR TITLE
Use page title and description in llms.txt links

### DIFF
--- a/Classes/Service/LlmsTxtGenerator.php
+++ b/Classes/Service/LlmsTxtGenerator.php
@@ -227,9 +227,9 @@ class LlmsTxtGenerator
         $link = new Link();
         $url = $this->createPageUrl((int)$page['uid'], $site, $languageId);
         $link->url($url);
-        $link->urlTitle('[Content Snippet]');
+        $link->urlTitle($page['nav_title'] ?: $page['title'] ?: '[untitled]');
 
-        $description = $this->extractDescription($content);
+        $description = $page['description'] ?: $this->extractDescription($content);
         if ($description) {
             $link->urlDetails($description);
         }


### PR DESCRIPTION
## Summary
- use actual page title instead of "Content Snippet" for llms.txt links
- include page meta description or extracted content as snippet after URL

## Testing
- `php -l Classes/Service/LlmsTxtGenerator.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_b_6890c1812bac8324852b83dc68424590