### PR TITLE
Add section-based grouping for llms.txt pages

### DIFF
--- a/Classes/Service/LlmsTxtGenerator.php
+++ b/Classes/Service/LlmsTxtGenerator.php
@@ -16,6 +16,7 @@ class LlmsTxtGenerator
 {
     private PageRepository $pageRepository;
     private ConnectionPool $connectionPool;
+    private array $sectionTitles = [];
 
     public function __construct(PageRepository $pageRepository, ConnectionPool $connectionPool)
     {
@@ -200,7 +201,7 @@ class LlmsTxtGenerator
         foreach ($pageTree as $node) {
             $this->addSectionsRecursively($sections, $node, $site, $languageId);
         }
-        return $sections;
+        return array_values($sections);
     }
 
     private function addSectionsRecursively(array &$sections, array $node, Site $site, int $languageId): void
@@ -230,8 +231,24 @@ class LlmsTxtGenerator
             return;
         }
 
-        $section = new Section();
-        $section->name($page['nav_title'] ?: $page['title'] ?: '[untitled]');
+        $sectionId = (int)($page['tx_llmstxt_section'] ?? 0);
+        if ($sectionId > 0) {
+            if (!isset($sections[$sectionId])) {
+                $sectionTitle = $this->getSectionTitle($sectionId);
+                $section = new Section();
+                $section->name($sectionTitle);
+                $sections[$sectionId] = $section;
+            }
+            $section = $sections[$sectionId];
+        } else {
+            $sectionKey = 'page-' . $page['uid'];
+            if (!isset($sections[$sectionKey])) {
+                $section = new Section();
+                $section->name($page['nav_title'] ?: $page['title'] ?: '[untitled]');
+                $sections[$sectionKey] = $section;
+            }
+            $section = $sections[$sectionKey];
+        }
 
         $link = new Link();
         $url = $this->createPageUrl((int)$page['uid'], $site, $languageId);
@@ -251,11 +268,30 @@ class LlmsTxtGenerator
         }
 
         $section->addLink($link);
-        $sections[] = $section;
 
         foreach ($node['children'] as $child) {
             $this->addSectionsRecursively($sections, $child, $site, $languageId);
         }
+    }
+
+    private function getSectionTitle(int $sectionId): string
+    {
+        if (!isset($this->sectionTitles[$sectionId])) {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_llmstxt_section');
+            $row = $queryBuilder
+                ->select('title')
+                ->from('tx_llmstxt_section')
+                ->where(
+                    $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($sectionId)),
+                    $queryBuilder->expr()->eq('hidden', $queryBuilder->createNamedParameter(0)),
+                    $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0))
+                )
+                ->executeQuery()
+                ->fetchAssociative();
+            $this->sectionTitles[$sectionId] = $row['title'] ?? ('Section ' . $sectionId);
+        }
+
+        return $this->sectionTitles[$sectionId];
     }
 
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ Once installed and activated, the extension will automatically provide a /llms.t
 
 1. Use the site's title and home page content for the header and description
 2. Generate sections based on the page tree structure
-3. Include page titles and descriptions (or content excerpts) for each page
-4. Only include visible, standard pages (doktype 1)
+3. Group pages that share a custom "section" into the same section of the llms.txt output
+4. Include page titles and descriptions (or content excerpts) for each page
+5. Only include visible, standard pages (doktype 1)
 
 ## Configuration Options (Future Enhancement)
 
@@ -110,7 +111,6 @@ Consider adding these features in future versions:
 - TypoScript configuration for customizing output
 - Backend module for preview and manual editing
 - Support for additional languages
-- Custom section grouping
 - Integration with SEO extensions for better descriptions
 - Support for .md versions of pages as per the llms.txt spec
 


### PR DESCRIPTION
## Summary
- Group pages in llms.txt by their `tx_llmstxt_section` value
- Query section titles and reuse sections for multiple pages
- Document custom section grouping feature

## Testing
- `composer install`
- `php -l Classes/Service/LlmsTxtGenerator.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_b_6890cdd29d8883248539b18ccbcaa42c