### PR TITLE
fix: skip localized pages when building tree

### DIFF
--- a/Classes/Service/LlmsTxtGenerator.php
+++ b/Classes/Service/LlmsTxtGenerator.php
@@ -154,6 +154,7 @@ class LlmsTxtGenerator
             ->from('pages')
             ->where(
                 $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($parentId)),
+                $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter(0)),
                 $queryBuilder->expr()->eq('hidden', $queryBuilder->createNamedParameter(0)),
                 $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0))
             )


### PR DESCRIPTION
## Summary
- avoid duplicate pages in llms.txt by excluding localized records from page tree

## Testing
- `php -l Classes/Service/LlmsTxtGenerator.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_b_6891c2d1e77083248cc6acecda60674d